### PR TITLE
Add missing edge to template graph

### DIFF
--- a/Proyecto_Aurora/menu.cpp
+++ b/Proyecto_Aurora/menu.cpp
@@ -265,6 +265,11 @@ void Menu::AddGraph()
             newEdge.setWeight(4);
             newEdge.setBidirectional(false);
             edgeList.push_back(newEdge);
+            newEdge.setSourceNode(1); // v2
+            newEdge.setTargetNode(3); // v4
+            newEdge.setWeight(7);
+            newEdge.setBidirectional(false);
+            edgeList.push_back(newEdge);
             system("cls");
         }
         else


### PR DESCRIPTION
+ Adds a missing edge to "aurora_dijkstra" template: v2 -> v4 (7).

Fixes #7.